### PR TITLE
Enforce single child

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,17 @@ language: node_js
 node_js:
   - "stable"
 sudo: false
-env: REACT_VERSION=15.3.x
+env: REACT_VERSION=15.5.x
 matrix:
   include:
     # These versions run different jobs in which we `yarn add` other releases
     # of react (& friends) to run our test suite against those as well
-    - env: REACT_VERSION=^0.14.9
-    - env: REACT_VERSION=15.x
+    - env: REACT_VERSION=0.14.9 REACT_ADDONS_TEST_UTILS_VERSION=^0.14.x
+    # testing the base 15 release
+    - env: REACT_VERSION=15.0.0 REACT_ADDONS_TEST_UTILS_VERSION=15.0.0
+    # testing the current highest supported release
+    - env: REACT_VERSION=15.5.4 REACT_ADDONS_TEST_UTILS_VERSION=15.5.1
 cache: yarn
 install:
   - yarn
-  - yarn add react@$REACT_VERSION react-dom@$REACT_VERSION react-addons-test-utils@$REACT_VERSION
+  - yarn add react@$REACT_VERSION react-dom@$REACT_VERSION react-addons-test-utils@$REACT_ADDONS_TEST_UTILS_VERSION

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ without shipping useless bits. TBD!
 - Support for `react@0.14.x` has been dropped, although _our_ tests pass
 this is likely to break in other apps. We now require `react@^0.14.9`, or
 anything on the `15.x` branch
+- `<RequireForAccess/>` now only accepts a *single* child node
+- The extraneous `<div/>` soup we were adding to the DOM has been removed,
+if you had previously relied on that `div.react-access-valid` for layout
+
 
 ## [0.0.5] - 2017-04-10
 ### Added

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/react-access.js",
   "scripts": {
     "test": "gulp test",
-    "prepublish": "gulp test && gulp build"
+    "prepublish": "in-publish && gulp test && gulp build || not-in-publish"
   },
   "repository": {
     "type": "git",
@@ -29,8 +29,8 @@
     "dist"
   ],
   "peerDependencies": {
-    "react": "^0.14.9 || 15.x",
-    "prop-types": "15.x"
+    "prop-types": "15.x",
+    "react": "^0.14.9 || 15.x"
   },
   "dependencies": {
     "lodash": "4.17.4"
@@ -54,7 +54,7 @@
     "gulp-rename": "1.2.2",
     "gulp-sourcemaps": "1.6.0",
     "gulp-uglify": "2.0.0",
-    "pleaserc": "^2.3.1",
+    "in-publish": "2.0.0",
     "prop-types": "15.5",
     "react": "15.5",
     "react-addons-test-utils": "15.5",

--- a/src/require-for-access.js
+++ b/src/require-for-access.js
@@ -1,4 +1,4 @@
-import React, {Component} from 'react';
+import React, {Component, Children} from 'react';
 import PropTypes from 'prop-types';
 
 export default class RequireForAccess extends Component {
@@ -18,9 +18,7 @@ export default class RequireForAccess extends Component {
     const {authorizeAccess} = this.context;
     const pass = authorizeAccess(permissions, requireAll);
 
-    return <div className={`react-access-${pass ? '' : 'in'}valid`}>
-      {pass ? children : invalidAccessComponent}
-    </div>;
+    return pass ? Children.only(children) : invalidAccessComponent;
   }
 
   static defaultProps = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1770,6 +1770,10 @@ ieee754@^1.1.4:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"
 
+in-publish@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/in-publish/-/in-publish-2.0.0.tgz#e20ff5e3a2afc2690320b6dc552682a9c7fadf51"
+
 indexof@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/indexof/-/indexof-0.0.1.tgz#82dc336d232b9062179d05ab3293a66059fd435d"
@@ -2674,10 +2678,6 @@ pinkie-promise@^2.0.0:
 pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
-
-pleaserc@^2.3.1:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/pleaserc/-/pleaserc-2.4.0.tgz#c1622c50c85c4c1de3df1e24c4b6a3d38b80f8c8"
 
 plur@^2.1.0:
   version "2.1.2"


### PR DESCRIPTION
This enforces the API to only allow for a single child to be provided for `<RequireForAccess/>`, which can be removed later on in React 16 / fiber land. It allows us to not pollute the dom with extra clutter and impose that on users to handle in their apps & layouts.